### PR TITLE
Fix base URL for meeting links

### DIFF
--- a/app/(root)/(home)/personal-room/page.tsx
+++ b/app/(root)/(home)/personal-room/page.tsx
@@ -50,10 +50,12 @@ const PersonalRoom = () => {
       });
     }
 
-    router.push(`https://zoomm.netlify.app/meeting/${meetingId}?personal=true`);
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || '';
+    router.push(`${baseUrl}/meeting/${meetingId}?personal=true`);
   };
 
-  const meetingLink = `https://zoomm.netlify.app/meeting/${meetingId}?personal=true`;
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || '';
+  const meetingLink = `${baseUrl}/meeting/${meetingId}?personal=true`;
 
   return (
     <section className="flex size-full flex-col gap-10 text-white">

--- a/components/MeetingTypeList.tsx
+++ b/components/MeetingTypeList.tsx
@@ -53,9 +53,10 @@ const MeetingTypeList = () => {
         },
       });
       setCallDetail(call);
-      if (!values.description) {
-        router.push(`https://zoomm.netlify.app/meeting/${call.id}`);
-      }
+        if (!values.description) {
+          const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || '';
+          router.push(`${baseUrl}/meeting/${call.id}`);
+        }
       toast({
         title: 'Meeting Created',
       });
@@ -67,7 +68,8 @@ const MeetingTypeList = () => {
 
   if (!client || !user) return <Loader />;
 
-  const meetingLink = `https://zoomm.netlify.app/meeting/${callDetail?.id}`;
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || '';
+  const meetingLink = `${baseUrl}/meeting/${callDetail?.id}`;
 
   return (
     <section className="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-4">


### PR DESCRIPTION
## Summary
- use `NEXT_PUBLIC_BASE_URL` in MeetingTypeList and personal room

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688776106854832090095570f6752b92