### PR TITLE
Add Clerk username modal

### DIFF
--- a/app/(root)/meeting/[id]/page.tsx
+++ b/app/(root)/meeting/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useUser } from '@clerk/nextjs';
 import { StreamCall, StreamTheme } from '@stream-io/video-react-sdk';
 import { useParams } from 'next/navigation';
@@ -10,12 +10,20 @@ import { useGetCallById } from '@/hooks/useGetCallById';
 import Alert from '@/components/Alert';
 import MeetingSetup from '@/components/MeetingSetup';
 import MeetingRoom from '@/components/MeetingRoom';
+import UsernameModal from '@/components/UsernameModal';
 
 const MeetingPage = () => {
   const { id } = useParams();
   const { isLoaded, user } = useUser();
   const { call, isCallLoading } = useGetCallById(id);
   const [isSetupComplete, setIsSetupComplete] = useState(false);
+  const [showUsernameModal, setShowUsernameModal] = useState(false);
+
+  useEffect(() => {
+    if (isLoaded && user && !user.username) {
+      setShowUsernameModal(true);
+    }
+  }, [isLoaded, user]);
 
   if (!isLoaded || isCallLoading) return <Loader />;
 
@@ -34,6 +42,10 @@ const MeetingPage = () => {
     <main className="h-screen w-full">
       <StreamCall call={call}>
         <StreamTheme>
+        <UsernameModal
+          open={showUsernameModal}
+          onOpenChange={setShowUsernameModal}
+        />
 
         {!isSetupComplete ? (
           <MeetingSetup setIsSetupComplete={setIsSetupComplete} />

--- a/components/UsernameModal.tsx
+++ b/components/UsernameModal.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import { useState } from 'react'
+import { useUser } from '@clerk/nextjs'
+
+import { Dialog, DialogContent } from './ui/dialog'
+import { Input } from './ui/input'
+import { Button } from './ui/button'
+
+interface UsernameModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+const UsernameModal = ({ open, onOpenChange }: UsernameModalProps) => {
+  const { user } = useUser()
+  const [username, setUsername] = useState('')
+
+  const saveUsername = async () => {
+    if (!user || !username) return
+    try {
+      await user.update({ username })
+      onOpenChange(false)
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex w-full max-w-[520px] flex-col gap-6 border-none bg-dark-1 px-6 py-9 text-white">
+        <h1 className="text-2xl font-bold">Choose a username</h1>
+        <Input
+          placeholder="Enter username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          className="border-none bg-dark-3 focus-visible:ring-0 focus-visible:ring-offset-0"
+        />
+        <Button className="bg-blue-1" onClick={saveUsername}>
+          Save
+        </Button>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default UsernameModal


### PR DESCRIPTION
## Summary
- prompt users to set a username before joining meetings
- add `UsernameModal` component

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887822d34a083209d9b24a88d97cb08