### PR TITLE
Fix username modal save

### DIFF
--- a/components/UsernameModal.tsx
+++ b/components/UsernameModal.tsx
@@ -20,6 +20,7 @@ const UsernameModal = ({ open, onOpenChange }: UsernameModalProps) => {
     if (!user || !username) return
     try {
       await user.update({ username })
+      await user.reload()
       onOpenChange(false)
     } catch (error) {
       console.error(error)

--- a/providers/StreamClientProvider.tsx
+++ b/providers/StreamClientProvider.tsx
@@ -21,14 +21,14 @@ const StreamVideoProvider = ({ children }: { children: ReactNode }) => {
       apiKey: API_KEY,
       user: {
         id: user?.id,
-        name: user?.username || user?.id,
+        name: user?.username ?? user?.id,
         image: user?.imageUrl,
       },
       tokenProvider,
     });
 
     setVideoClient(client);
-  }, [user, isLoaded]);
+  }, [isLoaded, user?.id, user?.username, user?.imageUrl]);
 
   if (!videoClient) return <Loader />;
 


### PR DESCRIPTION
## Summary
- ensure saving username reloads the user
- always use username in chat client when available

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887efa4cb048320bd56d5e47d6f7b1b